### PR TITLE
moved the datamart classes, into their own file

### DIFF
--- a/functions/Invoke-Installer.ps1
+++ b/functions/Invoke-Installer.ps1
@@ -1,132 +1,3 @@
-class Id {
-    [int] $Id = 0
-    [int] GetNewId() {
-        $this.Id--
-        return $this.Id
-    }
-}
-class DataMart {
-    [int] $Id
-    [guid] $ContentId
-    [string] $Name
-    [string] $DataMartType
-    [string] $Description
-    [string] $SqlAgentProxyName
-    [string] $SqlCredentialName
-    [decimal] $DefaultEngineVersion
-    [string] $SystemName
-    [string] $DataStewardFullName
-    [string] $DataStewardEmail
-    [string] $Version
-    [string] $IsHidden
-    [Connection[]] $Connections
-    [Entity[]] $Entities
-    [Binding[]] $Bindings
-    [ObjectAttributeValue[]] $AttributeValues
-}
-class Connection {
-    [int] $Id
-    [guid] $ContentId
-    [string] $SystemName
-    [string] $Description
-    [string] $DataSystemTypeCode
-    [string] $DataSystemVersion
-    [string] $SystemVendorName
-    [string] $SystemVersion
-    [ObjectAttributeValue[]] $AttributeValues
-}
-class Entity {
-    [int] $Id
-    [guid] $ContentId
-    [int] $ConnectionId
-    [string] $BusinessDescription
-    [string] $EntityName
-    [string] $TechnicalDescription
-    [string] $PersistenceType
-    [bool] $IsPublic
-    [bool] $AllowsDataEntry
-    [int] $RecordCountMismatchThreshold
-    [nullable[int]] $RecordCount
-    [nullable[system.datetimeoffset]] $LastSuccessfulLoadTimestamp
-    [nullable[system.datetimeoffset]] $LastModifiedTimestamp
-    [nullable[system.datetimeoffset]] $LastDeployedTimestamp
-    [Field[]] $Fields
-    [Index[]] $Indexes
-    [ObjectAttributeValue[]] $AttributeValues
-}
-class Binding {
-    [int] $Id
-    [guid] $ContentId
-    [string] $Name
-    [int] $DestinationEntityId
-    [int] $SourceConnectionId
-    [string] $BindingType
-    [string] $Classification
-    [string] $Description
-    [string] $LoadTypeCode
-    [string] $Status
-    [string] $GroupingColumn
-    [string] $GroupingFormat
-    [string] $GrainName
-    [ObjectAttributeValue[]] $AttributeValues
-}
-class Field {
-    [int] $Id
-    [guid] $ContentId
-    [string] $FieldName
-    [string] $BusinessDescription
-    [string] $TechnicalDescription
-    [string] $DataType
-    [string] $DefaultValue
-    [string] $DataSensitivity
-    [nullable[int]] $Ordinal
-    [string] $Status
-    [string] $ExampleData
-    # [nullable[system.datetimeoffset]] $ExampleDataUpdatetimestamp
-    [bool] $IsPrimaryKey
-    [bool] $IsNullable
-    [bool] $IsAutoIncrement
-    [bool] $ExcludeFromBaseView
-    [bool] $IsSystemField
-    [ObjectAttributeValue[]] $AttributeValues
-}
-class Index {
-    [int] $Id
-    [guid] $ContentId
-    [string] $IndexName
-    [bool] $IsUnique
-    [bool] $IsActive
-    [string] $IndexTypeCode
-    [bool] $IsColumnStore
-    [bool] $IsCapSystem
-    [nullable[system.datetimeoffset]] $LastModifiedTimestamp
-    [nullable[system.datetimeoffset]] $LastDeployedTimestamp
-    [IndexField[]] $IndexFields
-}
-class IndexField {
-    [int] $Id
-    [int] $IndexId
-    [nullable[int]] $FieldId
-    [int] $Ordinal
-    [bool] $IsDescending
-    [bool] $IsCovering
-}
-class ObjectAttributeValue {
-    [string] $AttributeName
-    [string] $AttributeValue
-}
-function NullableString {
-    param([string] $Text)
-    if ([string]::IsNullOrEmpty($Text)) {
-        return [nullstring]::value
-    }
-    else {
-        return $Text -replace "‘‘", """" -replace "’’", """" -replace "’", "'"
-    }
-}
-
-function True {return "1"}
-function False {return "0"}
 function Invoke-Installer {
     [CmdletBinding()]
     param (
@@ -135,6 +6,36 @@ function Invoke-Installer {
         [Parameter(Mandatory = $True, ValueFromPipelineByPropertyName)]
         [string]$OutDir
     )
+    begin {
+        $versionMinimum = [Version]'5.0'
+        if ($versionMinimum -gt $PSVersionTable.PSVersion)
+        { throw "This script requires PowerShell $versionMinimum" }
+
+        # Get function definition files.
+        $Functions = @( Get-ChildItem -Path "$PSScriptRoot\installer" -Filter *.ps1 -ErrorAction SilentlyContinue )
+
+        # Dot source the files
+        foreach ($Import in @($Functions)) {
+            try {
+                . $Import.fullname
+            }
+            catch {
+                Write-Error -Message "Failed to import function $($Import.fullname): $_"
+            }
+        }
+
+        function True {return "1"}
+        function False {return "0"}
+        function NullableString {
+            param([string] $Text)
+            if ([string]::IsNullOrEmpty($Text)) {
+                return [nullstring]::value
+            }
+            else {
+                return $Text -replace "‘‘", """" -replace "’’", """" -replace "’", "'"
+            }
+        }        
+    }
     process {
         try {
             Test-Path $File | Out-Null;

--- a/functions/installer/Class-DataMart.ps1
+++ b/functions/installer/Class-DataMart.ps1
@@ -1,0 +1,117 @@
+class Id {
+    [int] $Id = 0
+    [int] GetNewId() {
+        $this.Id--
+        return $this.Id
+    }
+}
+class DataMart {
+    [int] $Id
+    [guid] $ContentId
+    [string] $Name
+    [string] $DataMartType
+    [string] $Description
+    [string] $SqlAgentProxyName
+    [string] $SqlCredentialName
+    [decimal] $DefaultEngineVersion
+    [string] $SystemName
+    [string] $DataStewardFullName
+    [string] $DataStewardEmail
+    [string] $Version
+    [string] $IsHidden
+    [Connection[]] $Connections
+    [Entity[]] $Entities
+    [Binding[]] $Bindings
+    [ObjectAttributeValue[]] $AttributeValues
+}
+class Connection {
+    [int] $Id
+    [guid] $ContentId
+    [string] $SystemName
+    [string] $Description
+    [string] $DataSystemTypeCode
+    [string] $DataSystemVersion
+    [string] $SystemVendorName
+    [string] $SystemVersion
+    [ObjectAttributeValue[]] $AttributeValues
+}
+class Entity {
+    [int] $Id
+    [guid] $ContentId
+    [int] $ConnectionId
+    [string] $BusinessDescription
+    [string] $EntityName
+    [string] $TechnicalDescription
+    [string] $PersistenceType
+    [bool] $IsPublic
+    [bool] $AllowsDataEntry
+    [int] $RecordCountMismatchThreshold
+    [nullable[int]] $RecordCount
+    [nullable[system.datetimeoffset]] $LastSuccessfulLoadTimestamp
+    [nullable[system.datetimeoffset]] $LastModifiedTimestamp
+    [nullable[system.datetimeoffset]] $LastDeployedTimestamp
+    [Field[]] $Fields
+    [Index[]] $Indexes
+    [ObjectAttributeValue[]] $AttributeValues
+}
+class Binding {
+    [int] $Id
+    [guid] $ContentId
+    [string] $Name
+    [int] $DestinationEntityId
+    [int] $SourceConnectionId
+    [string] $BindingType
+    [string] $Classification
+    [string] $Description
+    [string] $LoadTypeCode
+    [string] $Status
+    [string] $GroupingColumn
+    [string] $GroupingFormat
+    [string] $GrainName
+    [ObjectAttributeValue[]] $AttributeValues
+}
+class Field {
+    [int] $Id
+    [guid] $ContentId
+    [string] $FieldName
+    [string] $BusinessDescription
+    [string] $TechnicalDescription
+    [string] $DataType
+    [string] $DefaultValue
+    [string] $DataSensitivity
+    [nullable[int]] $Ordinal
+    [string] $Status
+    [string] $ExampleData
+    # [nullable[system.datetimeoffset]] $ExampleDataUpdatetimestamp
+    [bool] $IsPrimaryKey
+    [bool] $IsNullable
+    [bool] $IsAutoIncrement
+    [bool] $ExcludeFromBaseView
+    [bool] $IsSystemField
+    [ObjectAttributeValue[]] $AttributeValues
+}
+class Index {
+    [int] $Id
+    [guid] $ContentId
+    [string] $IndexName
+    [bool] $IsUnique
+    [bool] $IsActive
+    [string] $IndexTypeCode
+    [bool] $IsColumnStore
+    [bool] $IsCapSystem
+    [nullable[system.datetimeoffset]] $LastModifiedTimestamp
+    [nullable[system.datetimeoffset]] $LastDeployedTimestamp
+    [IndexField[]] $IndexFields
+}
+class IndexField {
+    [int] $Id
+    [int] $IndexId
+    [nullable[int]] $FieldId
+    [int] $Ordinal
+    [bool] $IsDescending
+    [bool] $IsCovering
+}
+class ObjectAttributeValue {
+    [string] $AttributeName
+    [string] $AttributeValue
+}


### PR DESCRIPTION
 #7 
This update moves the PS Class commands used by the `Invoke-Installer` function into their own file and only try and create those classes when the Invoke-Installer function is called. This allowed me to add a PS Version check before running this function and throwing an error for those computers that haven't been upgraded to PowerShell 5.0 yet. The class function requires PowerShell version 5.0 or greater.

This essentially suppresses that version warning until the function that uses 5.0 is called!

Here's the main code that checks for the version.

```
$versionMinimum = [Version]'5.0'
if ($versionMinimum -gt $PSVersionTable.PSVersion)
{ throw "This script requires PowerShell $versionMinimum" }
```