### PR TITLE
Add Newtonsoft MaxDepth config

### DIFF
--- a/functions/Invoke-DataRaw.ps1
+++ b/functions/Invoke-DataRaw.ps1
@@ -62,6 +62,7 @@ function Invoke-DataRaw {
                 $jsonSettings = New-Object Newtonsoft.Json.JsonSerializerSettings
                 $jsonSettings.TypeNameHandling = 'Objects'
                 $jsonSettings.PreserveReferencesHandling = 'Objects'
+                $jsonSettings.MaxDepth = $null
                 $RawData = [Newtonsoft.Json.JsonConvert]::DeserializeObject($RawContent, $jsonSettings)
             }
             catch {

--- a/functions/Invoke-Installer.ps1
+++ b/functions/Invoke-Installer.ps1
@@ -81,6 +81,7 @@ function Invoke-Installer {
             $jsonSettings = New-Object Newtonsoft.Json.JsonSerializerSettings
             $jsonSettings.TypeNameHandling = 'Objects'
             $jsonSettings.PreserveReferencesHandling = 'Objects'
+            $jsonSettings.MaxDepth = $null
             $RawData = [Newtonsoft.Json.JsonConvert]::DeserializeObject($RawContent, $jsonSettings)
             if (Test-Path $OutBin) {
                 Remove-Item $OutBin -Recurse -Force


### PR DESCRIPTION
Newer versions of the newtonsoft DLL default MaxDepth to 64, when older versions defaulted to null. Explicitly setting null allows for very large/complex files to be deserialized.