### PR TITLE
Bugfixes: Source entity skip for SqlBindings without query and regex match fix

### DIFF
--- a/HCPosh.psm1
+++ b/HCPosh.psm1
@@ -201,6 +201,7 @@ function HCPosh {
                 $OutDataArray = HCPosh @params | Where-Object { $_ };
                 forEach ($OutData in $OutDataArray) {
                     write-host "Outdata Type: $($OutData.gettype())"
+                    write-host "OutData.Entities type: $($OutData.Entities.gettype())"
                     $NewOutDir = $OutDir + '\' + $OutData._hcposh.FileBaseName
                     if ($OutZip) {
                         if ($OutVar) {

--- a/HCPosh.psm1
+++ b/HCPosh.psm1
@@ -200,6 +200,7 @@ function HCPosh {
                 }
                 $OutDataArray = HCPosh @params | Where-Object { $_ };
                 forEach ($OutData in $OutDataArray) {
+                    write-host "Outdata Type: $($OutData.gettype())"
                     $NewOutDir = $OutDir + '\' + $OutData._hcposh.FileBaseName
                     if ($OutZip) {
                         if ($OutVar) {

--- a/HCPosh.psm1
+++ b/HCPosh.psm1
@@ -200,10 +200,6 @@ function HCPosh {
                 }
                 $OutDataArray = HCPosh @params | Where-Object { $_ };
                 forEach ($OutData in $OutDataArray) {
-                    write-host "Outdata Type: $($OutData.gettype())"
-                    write-host "OutData.Entities type: $($OutData.Entities.gettype())"
-                    write-host "OutData.Entities Length: $($OutData.Entities.Length)"
-
                     $NewOutDir = $OutDir + '\' + $OutData._hcposh.FileBaseName
                     if ($OutZip) {
                         if ($OutVar) {

--- a/HCPosh.psm1
+++ b/HCPosh.psm1
@@ -202,6 +202,8 @@ function HCPosh {
                 forEach ($OutData in $OutDataArray) {
                     write-host "Outdata Type: $($OutData.gettype())"
                     write-host "OutData.Entities type: $($OutData.Entities.gettype())"
+                    write-host "OutData.Entities Length: $($OutData.Entities.Length)"
+
                     $NewOutDir = $OutDir + '\' + $OutData._hcposh.FileBaseName
                     if ($OutZip) {
                         if ($OutVar) {

--- a/functions/Invoke-Docs.ps1
+++ b/functions/Invoke-Docs.ps1
@@ -35,7 +35,7 @@ function Invoke-Docs {
                 #if the entity doesn't have any bindings, exclude it.
 
                 #we create a new array and use a foreach loop because if there is only one entity remaining and we use powershell piping
-                #  the $Data.Entities array will transform to a PSCustomObject, which break the javascript code because the javascript
+                #  the $Data.Entities array will transform to a PSCustomObject, which breaks the javascript code because the javascript
                 #  is expecting an array, not a single PSCustomObject.
                 $newEntitiesArray = @()
                 $entitiesToKeep = $Data.Entities | Where-Object { $_ -ne $Data.Entities[$Data.Entities.ContentId.IndexOf($Entity.ContentId)] }

--- a/functions/Invoke-Docs.ps1
+++ b/functions/Invoke-Docs.ps1
@@ -195,6 +195,7 @@ function Invoke-Docs {
         $DocsDestinationPath = $OutDir;
         $DataFilePath = "$($DataDir)\dataMart.js";
         try {
+            Write-Host "$(" " * 4) Public Entity Count: $(($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count)"
             if (($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count -eq 0) { throw; }
             Copy-Item -Path $DocsSourcePath -Recurse -Destination $DocsDestinationPath -Force
             'dataMart = ' + ($Data | ConvertTo-Json -Depth 100 -Compress) | Out-File $DataFilePath -Encoding Default -Force | Out-Null

--- a/functions/Invoke-Docs.ps1
+++ b/functions/Invoke-Docs.ps1
@@ -206,7 +206,7 @@ function Invoke-Docs {
         $DocsDestinationPath = $OutDir;
         $DataFilePath = "$($DataDir)\dataMart.js";
         try {
-            Write-Host "$(" " * 4)Public Entity Count: $(($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count)"
+            $Msg = "$(" " * 4)Entity Count: $(($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count)"; Write-Host $Msg -ForegroundColor Cyan; Write-Verbose $Msg; Write-Log $Msg;
             if (($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count -eq 0) { throw; }
             Copy-Item -Path $DocsSourcePath -Recurse -Destination $DocsDestinationPath -Force
             'dataMart = ' + ($Data | ConvertTo-Json -Depth 100 -Compress) | Out-File $DataFilePath -Encoding Default -Force | Out-Null

--- a/functions/Invoke-Docs.ps1
+++ b/functions/Invoke-Docs.ps1
@@ -202,6 +202,7 @@ function Invoke-Docs {
         }
         catch {
             $Msg = "$(" " * 4)Unable to find valid public entities or An error occurred when trying to create the docs folder structure"; Write-Host $Msg -ForegroundColor Red; Write-Verbose $Msg; Write-Log $Msg 'error';
+            throw "$(" " * 4)Unable to find valid public entities or An error occurred when trying to create the docs folder structure"
         }
         if ($OutZip) {
             try {

--- a/functions/Invoke-Docs.ps1
+++ b/functions/Invoke-Docs.ps1
@@ -32,7 +32,18 @@ function Invoke-Docs {
             $Entity.Bindings = $Bindings;
 							
             if ($Entity.ClassificationCode -ne 'DataEntry' -and ($Entity.Bindings | Measure-Object).Count -eq 0) {
-                $Data.Entities = $Data.Entities | Where-Object { $_ -ne $Data.Entities[$Data.Entities.ContentId.IndexOf($Entity.ContentId)] }
+                #if the entity doesn't have any bindings, exclude it.
+
+                #we create a new array and use a foreach loop because if there is only one entity remaining and we use powershell piping
+                #  the $Data.Entities array will transform to a PSCustomObject, which break the javascript code because the javascript
+                #  is expecting an array, not a single PSCustomObject.
+                $newEntitiesArray = @()
+                $entitiesToKeep = $Data.Entities | Where-Object { $_ -ne $Data.Entities[$Data.Entities.ContentId.IndexOf($Entity.ContentId)] }
+                foreach($tempEntity in $entitiesToKeep){
+                    $newEntitiesArray += $tempEntity
+                }
+                #$Data.Entities = $Data.Entities | Where-Object { $_ -ne $Data.Entities[$Data.Entities.ContentId.IndexOf($Entity.ContentId)] }
+                $Data.Entities = $newEntitiesArray
             }
         }
         
@@ -195,7 +206,7 @@ function Invoke-Docs {
         $DocsDestinationPath = $OutDir;
         $DataFilePath = "$($DataDir)\dataMart.js";
         try {
-            Write-Host "$(" " * 4) Public Entity Count: $(($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count)"
+            Write-Host "$(" " * 4)Public Entity Count: $(($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count)"
             if (($Data.Entities | Where-Object $FilteredEntities | Measure-Object).Count -eq 0) { throw; }
             Copy-Item -Path $DocsSourcePath -Recurse -Destination $DocsDestinationPath -Force
             'dataMart = ' + ($Data | ConvertTo-Json -Depth 100 -Compress) | Out-File $DataFilePath -Encoding Default -Force | Out-Null


### PR DESCRIPTION
This is a duplicate PR from the other one I created earlier, except this one has two fixes in it instead of one.

Note: perhaps the `functions/Invoke-Data.ps1` fix should filter to active bindings only? (Instead of looking to see if the sql query is empty?)